### PR TITLE
Update mri_transforms.py

### DIFF
--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -492,7 +492,7 @@ class Normalize(DirectModule):
             # Compute the maximum and scale the input
             if self.percentile:
                 tview = -1.0 * T.modulus(data).view(-1)
-                scaling_factor, _ = torch.kthvalue(tview, int((1 - self.percentile) * tview.size()[0]))
+                scaling_factor, _ = torch.kthvalue(tview, int((1 - self.percentile) * tview.size()[0]) + 1)
                 scaling_factor = -1.0 * scaling_factor
             else:
                 scaling_factor = T.modulus(data).max()


### PR DESCRIPTION
`torch.kthvalue` returns error when k=0 (give 0th value). 0 should be replaced by 1 (1st value). 
This was not caused by old `torch` versions (<1.11.0).