### PR TITLE
Fix rim performance

### DIFF
--- a/direct/data/transforms.py
+++ b/direct/data/transforms.py
@@ -247,6 +247,24 @@ def modulus(data: torch.Tensor, complex_axis: int = -1) -> torch.Tensor:
     return (data**2).sum(complex_axis).sqrt()  # noqa
 
 
+def modulus_if_complex(data: torch.Tensor, complex_axis=-1) -> torch.Tensor:
+    """Compute modulus if complex tensor (has complex axis).
+
+    Parameters
+    ----------
+    data: torch.Tensor
+    complex_axis: int
+        Complex dimension along which the modulus will be calculated if that dimension is complex. Default: -1.
+
+    Returns
+    -------
+    torch.Tensor
+    """
+    if is_complex_data(data, complex_axis=complex_axis):
+        return modulus(data=data, complex_axis=complex_axis)
+    return data
+
+
 def roll_one_dim(data: torch.Tensor, shift: int, dim: int) -> torch.Tensor:
     """Similar to roll but only for one dim
 

--- a/direct/engine.py
+++ b/direct/engine.py
@@ -375,7 +375,7 @@ class Engine(ABC, DataDimensionality):
 
             metrics_dict = evaluate_dict(
                 metric_fns,
-                output.detach(),
+                T.modulus_if_complex(output.detach()),
                 data["target"].detach().to(self.device),
                 reduction="mean",
             )

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "scikit-learn>=1.0.1",
         "tensorboard>=2.7.0",
         "tqdm",
+        "protobuf==3.20.1",
     ],
     extras_require={
         "dev": [

--- a/tests/tests_data/test_transforms.py
+++ b/tests/tests_data/test_transforms.py
@@ -87,6 +87,43 @@ def test_modulus(shape):
 
 
 @pytest.mark.parametrize(
+    "shape",
+    [
+        [3, 3],
+        [4, 6],
+        [
+            3,
+            4,
+            8,
+        ],
+        [3, 4, 8, 5],
+    ],
+)
+@pytest.mark.parametrize("complex_axis", [0, 1, 2, -1, None])
+def test_modulus_if_complex(shape, complex_axis):
+    if complex_axis is not None:
+        if complex_axis != -1:
+            shape = (
+                shape[:complex_axis]
+                + [
+                    2,
+                ]
+                + shape[complex_axis:]
+            )
+        else:
+            shape.append(2)
+    data = create_input(shape)
+    if complex_axis is not None:
+        data = transforms.modulus_if_complex(data, complex_axis)
+        shape.pop(complex_axis)
+    else:
+        data = transforms.modulus_if_complex(data)
+        print(data.shape)
+
+    assert list(data.shape) == shape
+
+
+@pytest.mark.parametrize(
     "shape, dims",
     [
         [[3, 3], 0],

--- a/tests/tests_nn/test_rim_engine.py
+++ b/tests/tests_nn/test_rim_engine.py
@@ -71,4 +71,4 @@ def test_lpd_engine(shape, loss_fns, length, depth, scale_log):
     )
     loss_fns = engine.build_loss()
     out = engine._do_iteration(data, loss_fns)
-    assert out.output_image.shape == (shape[0],) + tuple(shape[2:-1])
+    assert out.output_image.shape == (shape[0],) + tuple(shape[2:])


### PR DESCRIPTION
RIM performs as it used to.
Changes:

* Re-implements some of the code removed in #194 with fixes:
  * `modulus_if_complex` requires for `complex_axis`
  * `rim_engine` permutes complex channel to last axis

* Tensorboard - dependancy fix (`protobuf`)