### PR TITLE
Add sampling masks (MagicMask, VariableDensityPoissonMask)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,5 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
+        python3 -m pip install -e ".[dev]"
     - name: Test with tox
       run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,4 +22,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox
+      run: tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,4 +22,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox
+      run: tox -e

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,4 +22,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox -e ${{ matrix.tox_env }}
+      run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
-        python3 -m pip install -e ".[dev]"
+        python -m pip install -e ".[dev]"
     - name: Test with tox
       run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
-        python3 -m pip install -e ".[dev]"
+        python3 setup.py build_ext -i
     - name: Test with tox
       run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,4 +22,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox -e
+      run: tox -a

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,5 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
+        python setup.py install build_ext --inplace
     - name: Test with tox
       run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,4 +22,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox -a
+      run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
-        python setup.py install build_ext --inplace
+        python3 -m pip install -e ".[dev]"
     - name: Test with tox
       run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,5 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
-        python3 setup.py build_ext -i
     - name: Test with tox
       run: tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include LICENSE
 include README.md
 
 recursive-include tests *
+recursive-include direct *.pyx *.pxd *.pxi *.py *.h *.ini *.npy *.txt *.in *.md
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: clean clean-test clean-pyc clean-cpy clean-build docs help
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT
@@ -26,7 +26,7 @@ BROWSER := python -c "$$BROWSER_PYSCRIPT"
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-clean: clean-build clean-pyc clean-test clean-docs ## remove all build, test, coverage, docs and Python artifacts
+clean: clean-build clean-pyc clean-cpy clean-test clean-docs ## remove all build, test, coverage, docs and Python and cython artifacts
 
 clean-build: ## remove build artifacts
 	rm -fr build/
@@ -40,6 +40,11 @@ clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-cpy: ## remove cython file artifacts
+	find . -name '*.c' -exec rm -f {} +
+	find . -name '*.cpp' -exec rm -f {} +
+	find . -name '*.so' -exec rm -f {} +
 
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/

--- a/direct/common/_poisson.pyx
+++ b/direct/common/_poisson.pyx
@@ -6,7 +6,6 @@
 #cython: unraisable_tracebacks=False
 
 import numpy as np
-
 cimport numpy as cnp
 from libc.math cimport cos, pi, sin
 from libc.stdlib cimport RAND_MAX, rand, srand
@@ -63,15 +62,17 @@ def poisson(
         num_actives = 1
 
         while num_actives > 0:
+            # Select a sample from active list
             i = randint(num_actives)
             px = pxs[i]
             py = pys[i]
-
             rx = radius_x[px, py]
             ry = radius_y[px, py]
+
             # Attempt to generate point
             done = False
             k = 0
+
             while not done and k < max_attempts:
 
                 # Generate point randomly from r and 2 * r

--- a/direct/common/_poisson.pyx
+++ b/direct/common/_poisson.pyx
@@ -2,11 +2,13 @@
 #cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
+#cython: overflowcheck=False
+#cython: unraisable_tracebacks=False
 
 import numpy as np
 
 cimport numpy as cnp
-from libc.math cimport abs, cos, pi, sin
+from libc.math cimport cos, pi, sin
 from libc.stdlib cimport RAND_MAX, rand, srand
 
 cnp.import_array()
@@ -17,17 +19,21 @@ cdef double random_uniform() nogil:
     cdef double r = rand()
     return r / RAND_MAX
 
+
 cdef int randint(int upper) nogil:
     """Produces a random integer in {0, 1, ..., upper-1}."""
     return int(random_uniform() * (upper))
+
 
 cdef inline Py_ssize_t fmax(Py_ssize_t one, Py_ssize_t two) nogil:
     """Max(a, b)."""
     return one if one > two else two
 
+
 cdef inline Py_ssize_t fmin(Py_ssize_t one, Py_ssize_t two) nogil:
     """Min(a, b)."""
     return one if one < two else two
+
 
 def poisson(
     int nx,
@@ -36,25 +42,20 @@ def poisson(
     cnp.ndarray[cnp.int_t, ndim=2, mode='c'] mask,
     cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] radius_x,
     cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] radius_y,
-    cnp.ndarray[cnp.int_t, ndim=1] calib,
     int seed
 ):
-    # Add calibration region
-    cdef int x, y, num_actives, i, k
-    cdef float rx, ry, v, t, qx, qy
 
+    cdef int x, y, num_actives, i, k
+    cdef float rx, ry, v, t, qx, qy, distance
     cdef Py_ssize_t startx, endx, starty, endy, px, py
 
     # initialize active list
     cdef cnp.ndarray[cnp.int_t, ndim=1, mode='c'] pxs = np.empty(nx * ny, dtype=int)
     cdef cnp.ndarray[cnp.int_t, ndim=1, mode='c'] pys = np.empty(nx * ny, dtype=int)
 
-    with nogil:
-        for x in range(int(nx / 2 - calib[0] / 2), int(nx / 2 + calib[0] / 2)):
-            for y in range(int(ny / 2 - calib[1] / 2), int(ny / 2 + calib[1] / 2)):
-                mask[x, y] = 1
+    srand(seed)
 
-        srand(seed)
+    with nogil:
 
         pxs[0] = randint(nx)
         pys[0] = randint(ny)
@@ -72,8 +73,9 @@ def poisson(
             done = False
             k = 0
             while not done and k < max_attempts:
+
                 # Generate point randomly from r and 2 * r
-                v = (random_uniform() * 3 + 1) ** 0.5
+                v = random_uniform() + 1
                 t = 2 * pi * random_uniform()
                 qx = px + v * rx * cos(t)
                 qy = py + v * ry * sin(t)
@@ -88,9 +90,8 @@ def poisson(
                     done = True
                     for x in range(startx, endx):
                         for y in range(starty, endy):
-                            if (mask[x, y] == 1
-                                and (((qx - x) / radius_x[x, y]) ** 2 +
-                                     ((qy - y) / (radius_y[x, y])) ** 2 < 1)):
+                            distance = ((qx - x) / radius_x[x, y]) ** 2 + ((qy - y) / (radius_y[x, y])) ** 2
+                            if (mask[x, y] == 1) and (distance < 1):
                                 done = False
                                 break
 
@@ -103,6 +104,6 @@ def poisson(
                 mask[pxs[num_actives], pys[num_actives]] = 1
                 num_actives += 1
             else:
-                pxs[i] = pxs[num_actives - 1]
-                pys[i] = pys[num_actives - 1]
                 num_actives -= 1
+                pxs[i] = pxs[num_actives]
+                pys[i] = pys[num_actives]

--- a/direct/common/_poisson.pyx
+++ b/direct/common/_poisson.pyx
@@ -89,8 +89,8 @@ def poisson(
                     for x in range(startx, endx):
                         for y in range(starty, endy):
                             if (mask[x, y] == 1
-                                and (((qx - x) / radius_x[y, x]) ** 2 +
-                                     ((qy - y) / (radius_y[y, x])) ** 2 < 1)):
+                                and (((qx - x) / radius_x[x, y]) ** 2 +
+                                     ((qy - y) / (radius_y[x, y])) ** 2 < 1)):
                                 done = False
                                 break
 

--- a/direct/common/_poisson.pyx
+++ b/direct/common/_poisson.pyx
@@ -43,6 +43,19 @@ def poisson(
     cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] radius_y,
     int seed
 ):
+    """
+    Notes
+    -----
+
+    * Code inspired and modified from [1]_ with BSD-3 licence, Copyright (c) 2016, Frank Ong, Copyright (c) 2016,
+        The Regents of the University of California [2]_.
+
+    References
+    ----------
+
+    .. [1] https://github.com/mikgroup/sigpy/blob/1817ff849d34d7cbbbcb503a1b310e7d8f95c242/sigpy/mri/samp.py#L158
+    .. [2] https://github.com/mikgroup/sigpy/blob/master/LICENSE
+    """
 
     cdef int x, y, num_actives, i, k
     cdef float rx, ry, v, t, qx, qy, distance

--- a/direct/common/_poisson.pyx
+++ b/direct/common/_poisson.pyx
@@ -1,0 +1,108 @@
+#cython: cdivision=True
+#cython: boundscheck=False
+#cython: nonecheck=False
+#cython: wraparound=False
+
+import numpy as np
+
+cimport numpy as cnp
+from libc.math cimport abs, cos, pi, sin
+from libc.stdlib cimport RAND_MAX, rand, srand
+
+cnp.import_array()
+
+
+cdef double random_uniform() nogil:
+    """Produces a random number in (0, 1)."""
+    cdef double r = rand()
+    return r / RAND_MAX
+
+cdef int randint(int upper) nogil:
+    """Produces a random integer in {0, 1, ..., upper-1}."""
+    return int(random_uniform() * (upper))
+
+cdef inline Py_ssize_t fmax(Py_ssize_t one, Py_ssize_t two) nogil:
+    """Max(a, b)."""
+    return one if one > two else two
+
+cdef inline Py_ssize_t fmin(Py_ssize_t one, Py_ssize_t two) nogil:
+    """Min(a, b)."""
+    return one if one < two else two
+
+def poisson(
+    int nx,
+    int ny,
+    int max_attempts,
+    cnp.ndarray[cnp.int_t, ndim=2, mode='c'] mask,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] radius_x,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] radius_y,
+    cnp.ndarray[cnp.int_t, ndim=1] calib,
+    int seed
+):
+    # Add calibration region
+    cdef int x, y, num_actives, i, k
+    cdef float rx, ry, v, t, qx, qy
+
+    cdef Py_ssize_t startx, endx, starty, endy, px, py
+
+    # initialize active list
+    cdef cnp.ndarray[cnp.int_t, ndim=1, mode='c'] pxs = np.empty(nx * ny, dtype=int)
+    cdef cnp.ndarray[cnp.int_t, ndim=1, mode='c'] pys = np.empty(nx * ny, dtype=int)
+
+    with nogil:
+        for x in range(int(nx / 2 - calib[0] / 2), int(nx / 2 + calib[0] / 2)):
+            for y in range(int(ny / 2 - calib[1] / 2), int(ny / 2 + calib[1] / 2)):
+                mask[x, y] = 1
+
+        srand(seed)
+
+        pxs[0] = randint(nx)
+        pys[0] = randint(ny)
+
+        num_actives = 1
+
+        while num_actives > 0:
+            i = randint(num_actives)
+            px = pxs[i]
+            py = pys[i]
+
+            rx = radius_x[px, py]
+            ry = radius_y[px, py]
+            # Attempt to generate point
+            done = False
+            k = 0
+            while not done and k < max_attempts:
+                # Generate point randomly from r and 2 * r
+                v = (random_uniform() * 3 + 1) ** 0.5
+                t = 2 * pi * random_uniform()
+                qx = px + v * rx * cos(t)
+                qy = py + v * ry * sin(t)
+
+                # Reject if outside grid or close to other points
+                if qx >= 0 and qx < nx and qy >= 0 and qy < ny:
+                    startx = fmax(int(qx - rx), 0)
+                    endx = fmin(int(qx + rx + 1), nx)
+                    starty = fmax(int(qy - ry), 0)
+                    endy = fmin(int(qy + ry + 1), ny)
+
+                    done = True
+                    for x in range(startx, endx):
+                        for y in range(starty, endy):
+                            if (mask[x, y] == 1
+                                and (((qx - x) / radius_x[y, x]) ** 2 +
+                                     ((qy - y) / (radius_y[y, x])) ** 2 < 1)):
+                                done = False
+                                break
+
+                k += 1
+
+            # Add point if done else remove from active list
+            if done:
+                pxs[num_actives] = int(qx)
+                pys[num_actives] = int(qy)
+                mask[pxs[num_actives], pys[num_actives]] = 1
+                num_actives += 1
+            else:
+                pxs[i] = pxs[num_actives - 1]
+                pys[i] = pys[num_actives - 1]
+                num_actives -= 1

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -7,8 +7,6 @@
 # https://github.com/facebookresearch/fastMRI/
 # The code can have been adjusted to our needs.
 
-# pylint: disable=arguments-differ
-
 import contextlib
 import logging
 from abc import abstractmethod
@@ -24,6 +22,8 @@ from direct.environment import DIRECT_CACHE_DIR
 from direct.types import Number
 from direct.utils import str_to_class
 from direct.utils.io import download_url
+
+# pylint: disable=arguments-differ
 
 __all__ = (
     "FastMRIRandomMaskFunc",
@@ -376,7 +376,6 @@ class FastMRIMagicMaskFunc(FastMRIMaskFunc):
             raise ValueError("Shape should have 3 or more dimensions")
 
         with temp_seed(self.rng, seed):
-            num_rows = shape[-3]
             num_cols = shape[-2]
 
             center_fraction, acceleration = self.choose_acceleration()
@@ -433,6 +432,7 @@ class CalgaryCampinasMaskFunc(BaseMaskFunc):
     }
 
     # TODO: Configuration improvements, so no **kwargs needed.
+    # pylint: disable=unused-argument
     def __init__(self, accelerations: Union[List[Number], Tuple[Number, ...]], **kwargs):  # noqa
         super().__init__(accelerations=accelerations, uniform_range=False)
 
@@ -867,7 +867,7 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
             try:
                 mask = self.poisson(num_rows, num_cols, center_fraction, acceleration, cython_seed)
                 return torch.from_numpy(mask[np.newaxis, ..., np.newaxis])
-            except:
+            except ValueError:
                 cython_seed += 1
         raise ValueError(
             f"Cannot generate mask to satisfy R={acceleration}, seed={seed}, max_attempts={self.max_attempts}."

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -244,7 +244,7 @@ class FastMRIRandomMaskFunc(FastMRIMaskFunc):
 class FastMRIEquispacedMaskFunc(FastMRIMaskFunc):
     r"""Equispaced vertical line mask function.
 
-    :class:`FastMRIEquispacedMaskFunc` creates a sub-sampling mask of a given shape. The mask selects a subset of columns
+    :class:`FastMRIEquispacedMaskFunc` creates a sub-sampling mask of given shape. The mask selects a subset of columns
     from the input k-space data. If the k-space data has N columns, the mask picks out:
 
         #.  :math:`N_{\text{low freqs}} = (N \times \text{center_fraction})` columns in the center corresponding

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -817,7 +817,7 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
         if slopes is not None:
             assert (
                 slopes[0] >= 0 and slopes[0] < slopes[1] and len(slopes) == 2
-            ), f"`slopes` must be an increasing sequence of two non-negative floats."
+            ), f"`slopes` must be an increasing sequence of two non-negative floats. Received {slopes}."
         self.slopes = slopes
 
     def mask_func(

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -854,7 +854,9 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
                 seed = int(np.mean(seed))
 
         if return_acs:
-            return torch.from_numpy(self.centered_disk_mask((num_rows, num_cols), center_fraction))
+            return torch.from_numpy(
+                self.centered_disk_mask((num_rows, num_cols), center_fraction)[np.newaxis, ..., np.newaxis]
+            )
 
         x, y = np.mgrid[:num_rows, :num_cols]
 

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -945,7 +945,9 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
         center_y = shape[1] // 2
 
         X, Y = np.indices(shape)
-        radius = int(np.linalg.norm(shape) * center_scale)
+
+        # r = sqrt( center_scale * H * W / pi)
+        radius = int(np.sqrt(np.prod(shape) * center_scale / np.pi))
 
         mask = ((X - center_x) ** 2 + (Y - center_y) ** 2) < radius**2
 

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -764,7 +764,8 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
     Notes
     -----
 
-    * Code inspired by [2]_.
+    * Code inspired and modified from [2]_ with BSD-3 licence, Copyright (c) 2016, Frank Ong, Copyright (c) 2016,
+        The Regents of the University of California [3]_.
 
     References
     ----------
@@ -772,7 +773,8 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
     .. [1] Bridson, Robert. “Fast Poisson Disk Sampling in Arbitrary Dimensions.” ACM SIGGRAPH 2007
         Sketches on - SIGGRAPH ’07, ACM Press, 2007, pp. 22-es. DOI.org (Crossref),
         https://doi.org/10.1145/1278780.1278807.
-    .. [2] https://github.com/mikgroup/sigpy
+    .. [2] https://github.com/mikgroup/sigpy/blob/1817ff849d34d7cbbbcb503a1b310e7d8f95c242/sigpy/mri/samp.py#L11
+    .. [3] https://github.com/mikgroup/sigpy/blob/master/LICENSE
 
     """
 

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -852,7 +852,7 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
             center_fraction, acceleration = self.choose_acceleration()
             if seed is None:
                 # cython requires specific seed type so it cannot be None
-                cython_seed = self.rng.randint(0, 1e4)
+                cython_seed = 0
             elif isinstance(seed, (tuple, list)):
                 # cython `srand` method takes only integers
                 cython_seed = int(np.mean(seed))

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 
 import direct.data.transforms as T
-from direct.common._poisson import poisson as _poisson
+from direct.common._poisson import poisson as _poisson  # pylint: disable=no-name-in-module
 from direct.environment import DIRECT_CACHE_DIR
 from direct.types import Number
 from direct.utils import str_to_class

--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -7,6 +7,8 @@
 # https://github.com/facebookresearch/fastMRI/
 # The code can have been adjusted to our needs.
 
+# pylint: disable=arguments-differ
+
 import contextlib
 import logging
 from abc import abstractmethod
@@ -222,7 +224,6 @@ class FastMRIRandomMaskFunc(FastMRIMaskFunc):
             raise ValueError("Shape should have 3 or more dimensions")
 
         with temp_seed(self.rng, seed):
-            num_rows = shape[-3]
             num_cols = shape[-2]
 
             center_fraction, acceleration = self.choose_acceleration()
@@ -300,7 +301,6 @@ class FastMRIEquispacedMaskFunc(FastMRIMaskFunc):
             raise ValueError("Shape should have 3 or more dimensions")
 
         with temp_seed(self.rng, seed):
-            num_rows = shape[-3]
             num_cols = shape[-2]
 
             center_fraction, acceleration = self.choose_acceleration()
@@ -851,7 +851,7 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
             if seed is None:
                 # cython requires specific seed type so it cannot be None
                 cython_seed = self.rng.randint(0, 1e4)
-            elif isinstance(seed, tuple) or isinstance(seed, list):
+            elif isinstance(seed, (tuple, list)):
                 # cython `srand` method takes only integers
                 cython_seed = int(np.mean(seed))
             elif isinstance(seed, int):
@@ -867,7 +867,7 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
             try:
                 mask = self.poisson(num_rows, num_cols, center_fraction, acceleration, cython_seed)
                 return torch.from_numpy(mask[np.newaxis, ..., np.newaxis])
-            except Exception as e:
+            except:
                 cython_seed += 1
         raise ValueError(
             f"Cannot generate mask to satisfy R={acceleration}, seed={seed}, max_attempts={self.max_attempts}."
@@ -896,7 +896,7 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
         seed: int
             Seed to be used by cython function. Default: 0.
         """
-
+        # pylint: disable=too-many-locals
         x, y = np.mgrid[:num_rows, :num_cols]
 
         x = np.maximum(abs(x - num_rows / 2) - self.calibration[0] / 2, 0)

--- a/direct/nn/crossdomain/crossdomain.py
+++ b/direct/nn/crossdomain/crossdomain.py
@@ -148,7 +148,7 @@ class CrossDomainNetwork(nn.Module):
                     sampling_mask == 0,
                     torch.tensor([0.0], dtype=kspace.dtype).to(kspace.device),
                     kspace,
-                ),
+                ).contiguous(),
                 self._spatial_dims,
             ),
             sensitivity_map,

--- a/direct/nn/kikinet/kikinet.py
+++ b/direct/nn/kikinet/kikinet.py
@@ -160,7 +160,7 @@ class KIKINet(nn.Module):
                         sampling_mask == 0,
                         torch.tensor([0.0], dtype=kspace.dtype).to(kspace.device),
                         kspace,
-                    ),
+                    ).contiguous(),
                     self._spatial_dims,
                 ),
                 sensitivity_map,

--- a/direct/nn/lpd/lpd.py
+++ b/direct/nn/lpd/lpd.py
@@ -242,7 +242,7 @@ class LPDNet(nn.Module):
                     sampling_mask == 0,
                     torch.tensor([0.0], dtype=kspace.dtype).to(kspace.device),
                     kspace,
-                ),
+                ).contiguous(),
                 self._spatial_dims,
             ),
             sensitivity_map,

--- a/installation.rst
+++ b/installation.rst
@@ -40,7 +40,7 @@ Install using ``conda``
 
    .. code-block::
 
-      pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+      pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
 
    **otherwise**\ , install the latest PyTorch CPU version (not recommended):
 
@@ -54,6 +54,12 @@ Install using ``conda``
    .. code-block::
 
       python3 setup.py install
+
+   or
+
+   .. code-block::
+
+      python3 -m pip install -e ".[dev]"
 
    This will install ``direct`` as a python module.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,8 @@ python =
     3.9: py39
 
 [testenv]
-wheel = true
 deps = pytest
-extras = 
-    dev
-    alldeps: all
+extras = dev
 allowlist_externals = sh
 commands=
      sh -c "direct --help > /dev/null"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ generated-members=['numpy.*', 'torch.*', 'np.*']
 [tool.tox]
 legacy_tox_ini = """
 [tox]
+isolated_build = True
 envlist = py38, py39
 skip_missing_interpreters=true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ generated-members=['numpy.*', 'torch.*', 'np.*']
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-isolated_build = True
+isolated_build = true
 envlist = py38, py39
 skip_missing_interpreters=true
 
@@ -54,6 +54,7 @@ python =
     3.9: py39
 
 [testenv]
+wheel = true
 deps = pytest
 extras = 
     dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ generated-members=['numpy.*', 'torch.*', 'np.*']
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-isolated_build = true
 envlist = py38, py39
 skip_missing_interpreters=true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ python =
 
 [testenv]
 deps = pytest
-extras = dev
+extras = 
+    dev
+    alldeps: all
 allowlist_externals = sh
 commands=
      sh -c "direct --help > /dev/null"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 """The setup script."""
 
 import ast
+import pathlib
 
 from setuptools import Extension, find_packages, setup  # type: ignore
 from setuptools.command.build_ext import build_ext
@@ -89,5 +90,7 @@ setup(
     version=version,
     zip_safe=False,
     cmdclass={"build_ext": _build_ext},
-    ext_modules=[Extension("direct.common._poisson", sources=["direct/common/_poisson.pyx"])],
+    ext_modules=[
+        Extension("direct.common._poisson", sources=[str(pathlib.Path(".") / "direct" / "common" / "_poisson.pyx")])
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "scikit-learn>=1.0.1",
         "tensorboard>=2.7.0",
         "tqdm",
+        "protobuf==3.20.1",
     ],
     extras_require={
         "dev": [
@@ -75,7 +76,6 @@ setup(
             "boto3",
             "ismrmrd>=1.9.5",
             "pyxb",
-            "protobuf==3.20.1",
         ],
     },
     license="Apache Software License 2.0",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "numpy>=1.21.2",
         "h5py==3.3.0",
         "omegaconf==2.1.1",
-        "torch>=1.10.2",
+        "torch==1.11.0",
         "torchvision",
         "scikit-image>=0.19.0",
         "scikit-learn>=1.0.1",

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
             "boto3",
             "ismrmrd>=1.9.5",
             "pyxb",
+            "protobuf==3.20.1",
         ],
     },
     license="Apache Software License 2.0",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import Extension, find_packages, setup  # type: ignore
 from setuptools.command.build_ext import build_ext
 
 
-class build_ext(build_ext):
+class _build_ext(build_ext):
     def run(self):
         import numpy as np
 
@@ -88,6 +88,6 @@ setup(
     url="https://github.com/NKI-AI/direct",
     version=version,
     zip_safe=False,
-    cmdclass={"build_ext": build_ext},
-    ext_modules=[Extension("direct.common._poisson", sources=["./direct/common/_poisson.pyx"])],
+    cmdclass={"build_ext": _build_ext},
+    ext_modules=[Extension("direct.common._poisson", sources=["direct/common/_poisson.pyx"])],
 )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "numpy>=1.21.2",
         "h5py==3.3.0",
         "omegaconf==2.1.1",
-        "torch>=1.10.0",
+        "torch>=1.10.2",
         "torchvision",
         "scikit-image>=0.19.0",
         "scikit-learn>=1.0.1",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
     ],
     extras_require={
         "dev": [
-            "cython",
             "pytest",
             "sphinx_copybutton",
             "numpydoc",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "numpy>=1.21.2",
         "h5py==3.3.0",
         "omegaconf==2.1.1",
-        "torch==1.11.0",
+        "torch>=1.10.0",
         "torchvision",
         "scikit-image>=0.19.0",
         "scikit-learn>=1.0.1",

--- a/tests/tests_common/test_subsample.py
+++ b/tests/tests_common/test_subsample.py
@@ -197,13 +197,25 @@ def test_same_across_volumes_mask_spiral(shape, accelerations):
         ([2, 64, 64, 2], [8, 4], [0.04, 0.08]),
     ],
 )
-def test_apply_mask_poisson(shape, accelerations, center_scales):
+@pytest.mark.parametrize(
+    "seed",
+    [
+        None,
+        10,
+        100,
+        1000,
+        np.random.randint(0, 10000),
+        list(np.random.randint(0, 10000, 20)),
+        tuple(np.random.randint(100000, 1000000, 30)),
+    ],
+)
+def test_apply_mask_poisson(shape, accelerations, center_scales, seed):
     mask_func = VariableDensityPoissonMaskFunc(
         accelerations=accelerations,
         center_scales=center_scales,
     )
-    mask = mask_func(shape[1:], seed=123)
-    acs_mask = mask_func(shape[1:], seed=123, return_acs=True)
+    mask = mask_func(shape[1:], seed=seed)
+    acs_mask = mask_func(shape[1:], seed=seed, return_acs=True)
     expected_mask_shape = (1, shape[1], shape[2], 1)
     print(mask, acs_mask)
     assert mask.max() == 1

--- a/tests/tests_common/test_subsample.py
+++ b/tests/tests_common/test_subsample.py
@@ -217,11 +217,11 @@ def test_apply_mask_poisson(shape, accelerations, center_scales, seed):
     mask = mask_func(shape[1:], seed=seed)
     acs_mask = mask_func(shape[1:], seed=seed, return_acs=True)
     expected_mask_shape = (1, shape[1], shape[2], 1)
-    print(mask, acs_mask)
     assert mask.max() == 1
     assert mask.min() == 0
     assert mask.shape == expected_mask_shape
-    assert np.allclose(mask & acs_mask, acs_mask)
+    if seed is not None:
+        assert np.allclose(mask & acs_mask, acs_mask)
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_common/test_subsample.py
+++ b/tests/tests_common/test_subsample.py
@@ -11,9 +11,20 @@ import numpy as np
 import pytest
 import torch
 
-from direct.common.subsample import FastMRIRandomMaskFunc, RadialMaskFunc, SpiralMaskFunc
+from direct.common.subsample import (
+    FastMRIEquispacedMaskFunc,
+    FastMRIMagicMaskFunc,
+    FastMRIRandomMaskFunc,
+    RadialMaskFunc,
+    SpiralMaskFunc,
+    VariableDensityPoissonMaskFunc,
+)
 
 
+@pytest.mark.parametrize(
+    "mask_func",
+    [FastMRIRandomMaskFunc, FastMRIEquispacedMaskFunc, FastMRIMagicMaskFunc],
+)
 @pytest.mark.parametrize(
     "center_fracs, accelerations, batch_size, dim",
     [
@@ -21,8 +32,8 @@ from direct.common.subsample import FastMRIRandomMaskFunc, RadialMaskFunc, Spira
         ([0.2, 0.4], [4, 8], 2, 368),
     ],
 )
-def test_fastmri_random_mask_reuse(center_fracs, accelerations, batch_size, dim):
-    mask_func = FastMRIRandomMaskFunc(center_fracs, accelerations)
+def test_fastmri_mask_reuse(mask_func, center_fracs, accelerations, batch_size, dim):
+    mask_func = mask_func(center_fractions=center_fracs, accelerations=accelerations)
     shape = (batch_size, dim, dim, 2)
     mask1 = mask_func(shape, seed=123)
     mask2 = mask_func(shape, seed=123)
@@ -32,14 +43,18 @@ def test_fastmri_random_mask_reuse(center_fracs, accelerations, batch_size, dim)
 
 
 @pytest.mark.parametrize(
+    "mask_func",
+    [FastMRIRandomMaskFunc, FastMRIEquispacedMaskFunc, FastMRIMagicMaskFunc],
+)
+@pytest.mark.parametrize(
     "center_fracs, accelerations, batch_size, dim",
     [
         ([0.2], [4], 4, 320),
         ([0.2, 0.4], [4, 8], 2, 368),
     ],
 )
-def test_fastmri_random_mask_low_freqs(center_fracs, accelerations, batch_size, dim):
-    mask_func = FastMRIRandomMaskFunc(center_fracs, accelerations)
+def test_fastmri_mask_low_freqs(mask_func, center_fracs, accelerations, batch_size, dim):
+    mask_func = mask_func(center_fractions=center_fracs, accelerations=accelerations)
     shape = (batch_size, dim, dim, 2)
     mask = mask_func(shape, seed=123)
     mask_shape = [1] * (len(shape) + 1)
@@ -58,18 +73,18 @@ def test_fastmri_random_mask_low_freqs(center_fracs, accelerations, batch_size, 
 
 
 @pytest.mark.parametrize(
+    "mask_func",
+    [FastMRIRandomMaskFunc, FastMRIEquispacedMaskFunc, FastMRIMagicMaskFunc],
+)
+@pytest.mark.parametrize(
     "shape, center_fractions, accelerations",
     [
         ([4, 32, 32, 2], [0.08], [4]),
         ([2, 64, 64, 2], [0.04, 0.08], [8, 4]),
     ],
 )
-def test_apply_mask_fastmri(shape, center_fractions, accelerations):
-    mask_func = FastMRIRandomMaskFunc(
-        center_fractions=center_fractions,
-        accelerations=accelerations,
-        uniform_range=False,
-    )
+def test_apply_mask_fastmri(mask_func, shape, center_fractions, accelerations):
+    mask_func = mask_func(center_fractions=center_fractions, accelerations=accelerations)
     mask = mask_func(shape[1:], seed=123)
     acs_mask = mask_func(shape[1:], seed=123, return_acs=True)
     expected_mask_shape = (1, shape[1], shape[2], 1)
@@ -81,18 +96,18 @@ def test_apply_mask_fastmri(shape, center_fractions, accelerations):
 
 
 @pytest.mark.parametrize(
+    "mask_func",
+    [FastMRIRandomMaskFunc, FastMRIEquispacedMaskFunc, FastMRIMagicMaskFunc],
+)
+@pytest.mark.parametrize(
     "shape, center_fractions, accelerations",
     [
         ([4, 32, 32, 2], [0.08], [4]),
         ([2, 64, 64, 2], [0.04, 0.08], [8, 4]),
     ],
 )
-def test_same_across_volumes_mask_fastmri(shape, center_fractions, accelerations):
-    mask_func = FastMRIRandomMaskFunc(
-        center_fractions=center_fractions,
-        accelerations=accelerations,
-        uniform_range=False,
-    )
+def test_same_across_volumes_mask_fastmri(mask_func, shape, center_fractions, accelerations):
+    mask_func = mask_func(center_fractions=center_fractions, accelerations=accelerations)
     num_slices = shape[0]
     masks = [mask_func(shape[1:], seed=123) for _ in range(num_slices)]
 
@@ -168,6 +183,46 @@ def test_apply_mask_spiral(shape, accelerations):
 def test_same_across_volumes_mask_spiral(shape, accelerations):
     mask_func = SpiralMaskFunc(
         accelerations=accelerations,
+    )
+    num_slices = shape[0]
+    masks = [mask_func(shape[1:], seed=123) for _ in range(num_slices)]
+
+    assert all(np.allclose(masks[_], masks[_ + 1]) for _ in range(num_slices - 1))
+
+
+@pytest.mark.parametrize(
+    "shape, accelerations, center_scales",
+    [
+        ([4, 32, 32, 2], [4], [0.08]),
+        ([2, 64, 64, 2], [8, 4], [0.04, 0.08]),
+    ],
+)
+def test_apply_mask_poisson(shape, accelerations, center_scales):
+    mask_func = VariableDensityPoissonMaskFunc(
+        accelerations=accelerations,
+        center_scales=center_scales,
+    )
+    mask = mask_func(shape[1:], seed=123)
+    acs_mask = mask_func(shape[1:], seed=123, return_acs=True)
+    expected_mask_shape = (1, shape[1], shape[2], 1)
+    print(mask, acs_mask)
+    assert mask.max() == 1
+    assert mask.min() == 0
+    assert mask.shape == expected_mask_shape
+    assert np.allclose(mask & acs_mask, acs_mask)
+
+
+@pytest.mark.parametrize(
+    "shape, accelerations, center_scales",
+    [
+        ([4, 32, 32, 2], [4], [0.08]),
+        ([2, 64, 64, 2], [8, 4], [0.04, 0.08]),
+    ],
+)
+def test_same_across_volumes_mask_spiral(shape, accelerations, center_scales):
+    mask_func = VariableDensityPoissonMaskFunc(
+        accelerations=accelerations,
+        center_scales=center_scales,
     )
     num_slices = shape[0]
     masks = [mask_func(shape[1:], seed=123) for _ in range(num_slices)]


### PR DESCRIPTION
Adding:
* Variable density Poisson masking function
  * cython implementation
  * setup.py changes 
* Fastmri's Magic masking function
* Additional tests
Update:
* `torch.where` output needed to be made `contiguous` to be inputted to fft, due to new torch version