### PR TITLE
Some transforms modules, pre and post transforms, update transforms config

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@22.1.0
+      - uses: psf/black@22.3.0

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@22.3.0
+      - uses: psf/black@22.12.0

--- a/direct/algorithms/mri_algorithms.py
+++ b/direct/algorithms/mri_algorithms.py
@@ -174,6 +174,9 @@ class EspiritCalibration(DirectModule):
         """
         acs_mask = sample["acs_mask"]
         kspace = sample[self.kspace_key]
-        sensitivity_map = self.calculate_sensitivity_map(acs_mask, kspace)
+        sensitivity_map = torch.stack(
+            [self.calculate_sensitivity_map(acs_mask[_], kspace[_]) for _ in range(kspace.shape[0])],
+            dim=0,
+        ).to(kspace.device)
 
         return sensitivity_map

--- a/direct/data/datasets_config.py
+++ b/direct/data/datasets_config.py
@@ -13,21 +13,52 @@ from direct.config.defaults import BaseConfig
 
 
 @dataclass
-class TransformsConfig(BaseConfig):
-    masking: MaskingConfig = MaskingConfig()
+class CropTransformConfig(BaseConfig):
     crop: Optional[Tuple[int, int]] = None
     crop_type: Optional[str] = "uniform"
     image_center_crop: bool = False
-    padding_eps: float = 0.001
+
+
+@dataclass
+class SensitivityMapEstimationTransformConfig(BaseConfig):
     estimate_sensitivity_maps: bool = True
-    estimate_body_coil_image: bool = False
+    sensitivity_maps_type: str = "rss_estimate"
+    sensitivity_maps_espirit_threshold: Optional[float] = 0.05
+    sensitivity_maps_espirit_kernel_size: Optional[int] = 6
+    sensitivity_maps_espirit_crop: Optional[float] = 0.95
+    sensitivity_maps_espirit_max_iters: Optional[int] = 30
     sensitivity_maps_gaussian: Optional[float] = 0.7
+
+
+@dataclass
+class RandomAugmentationTransformsConfig(BaseConfig):
+    random_rotation: bool = False
+    random_rotation_degrees: Tuple[int, ...] = (-90, 90)
+    random_rotation_probability: Optional[float] = 0.5
+    random_flip: bool = False
+    random_flip_type: Optional[str] = "random"
+    random_flip_probability: Optional[float] = 0.5
+
+
+@dataclass
+class NormalizationTransformConfig(BaseConfig):
+    scaling_key: Optional[str] = "masked_kspace"
+    scale_percentile: Optional[float] = 0.99
+
+
+@dataclass
+class TransformsConfig(BaseConfig):
+    masking: MaskingConfig = MaskingConfig()
+    cropping: CropTransformConfig = CropTransformConfig()
+    random_augmentations: RandomAugmentationTransformsConfig = RandomAugmentationTransformsConfig()
+    padding_eps: float = 0.001
+    estimate_body_coil_image: bool = False
+    sensitivity_map_estimation: SensitivityMapEstimationTransformConfig = SensitivityMapEstimationTransformConfig()
+    normalization: NormalizationTransformConfig = NormalizationTransformConfig()
     delete_acs_mask: bool = True
     delete_kspace: bool = True
     image_recon_type: str = "rss"
     pad_coils: Optional[int] = None
-    scaling_key: Optional[str] = "masked_kspace"
-    scale_percentile: Optional[float] = 0.99
     use_seed: bool = True
 
 

--- a/direct/train.py
+++ b/direct/train.py
@@ -22,7 +22,7 @@ from direct.data.mri_transforms import build_mri_transforms
 from direct.environment import setup_training_environment
 from direct.launch import launch
 from direct.types import PathOrString
-from direct.utils import remove_keys, set_all_seeds, str_to_class
+from direct.utils import dict_flatten, remove_keys, set_all_seeds, str_to_class
 from direct.utils.dataset import get_filenames_for_datasets_from_config
 from direct.utils.io import check_is_valid_url, read_json
 
@@ -81,7 +81,7 @@ def build_transforms_from_environment(env, dataset_config: DictConfig) -> Callab
         backward_operator=env.engine.backward_operator,
         mask_func=build_masking_function(**dataset_config.transforms.masking),
     )
-    return mri_transforms_func(**remove_keys(dataset_config.transforms, "masking"))  # type: ignore
+    return mri_transforms_func(**dict_flatten(dict(remove_keys(dataset_config.transforms, "masking"))))  # type: ignore
 
 
 def build_training_datasets_from_environment(

--- a/direct/types.py
+++ b/direct/types.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import pathlib
 from enum import Enum
-from typing import NewType, Union
+from typing import Dict, NewType, Union
 
 import torch
+from omegaconf.omegaconf import DictConfig
 from torch import nn as nn
 from torch.cuda.amp import GradScaler
 
+DictOrDictConfig = Union[Dict, DictConfig]
 Number = Union[float, int]
 PathOrString = Union[pathlib.Path, str]
 FileOrUrl = NewType("FileOrUrl", PathOrString)

--- a/direct/types.py
+++ b/direct/types.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 
 import pathlib
 from enum import Enum
-from typing import Dict, NewType, Union
+from typing import NewType, Union
 
 import torch
 from omegaconf.omegaconf import DictConfig
 from torch import nn as nn
 from torch.cuda.amp import GradScaler
 
-DictOrDictConfig = Union[Dict, DictConfig]
+DictOrDictConfig = Union[dict, DictConfig]
 Number = Union[float, int]
 PathOrString = Union[pathlib.Path, str]
 FileOrUrl = NewType("FileOrUrl", PathOrString)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -15,7 +15,14 @@ from direct.config.defaults import (
     TrainingConfig,
     ValidationConfig,
 )
-from direct.data.datasets_config import DatasetConfig, MaskingConfig, TransformsConfig
+from direct.data.datasets_config import (
+    CropTransformConfig,
+    DatasetConfig,
+    MaskingConfig,
+    NormalizationTransformConfig,
+    SensitivityMapEstimationTransformConfig,
+    TransformsConfig,
+)
 from direct.launch import launch
 from direct.train import setup_train
 
@@ -33,10 +40,10 @@ def create_test_cfg(
 ):
     # Configs
     transforms_config = TransformsConfig(
-        estimate_sensitivity_maps=True,
-        scaling_key="masked_kspace",
+        normalization=NormalizationTransformConfig(scaling_key="masked_kspace"),
         masking=MaskingConfig(name="FastMRIRandom"),
-        crop=(64, 64),
+        cropping=CropTransformConfig(crop=(32, 32)),
+        sensitivity_map_estimation=SensitivityMapEstimationTransformConfig(estimate_sensitivity_maps=True),
     )
 
     new_class = make_dataclass(


### PR DESCRIPTION
* Some transforms are now nn.Modules and can be implemented batch-wise
* MRI transforms split to `pre-transforms` and `post-transforms`. Plan is to call `pre-transforms` before collation and `post-transforms` after collation on device [not implemented yet, functionality now is as it was].
* Adding augmentation transforms: `RandomFlip` and `RandomRotation`
* Updates transforms configuration by flattening DictConfig from omegaconf