### PR TITLE
CLI Entry Point, Reformat with Black v25.1.0

### DIFF
--- a/direct/common/subsample.py
+++ b/direct/common/subsample.py
@@ -1920,9 +1920,9 @@ class VariableDensityPoissonMaskFunc(BaseMaskFunc):
         self.max_attempts = max_attempts
         self.tol = tol
         if slopes is not None:
-            assert slopes[0] >= 0 and slopes[0] < slopes[1] and len(slopes) == 2, (
-                f"`slopes` must be an increasing sequence of two non-negative floats. Received {slopes}."
-            )
+            assert (
+                slopes[0] >= 0 and slopes[0] < slopes[1] and len(slopes) == 2
+            ), f"`slopes` must be an increasing sequence of two non-negative floats. Received {slopes}."
         self.slopes = slopes
 
     def mask_func(
@@ -2696,7 +2696,9 @@ class KtUniformMaskFunc(KtBaseMaskFunc):
             ptmp = np.zeros(num_cols)
             ttmp = np.zeros(nt)
 
-            ptmp[np.arange(self.rng.randint(0, adjusted_acceleration), num_cols, adjusted_acceleration).astype(int)] = 1
+            ptmp[
+                np.arange(self.rng.randint(0, adjusted_acceleration), num_cols, adjusted_acceleration).astype(int)
+            ] = 1
             ttmp[np.arange(self.rng.randint(0, acceleration), nt, acceleration).astype(int)] = 1
 
         top_mat = toeplitz(ptmp, ttmp)

--- a/direct/data/datasets.py
+++ b/direct/data/datasets.py
@@ -405,7 +405,9 @@ class FastMRIDataset(H5SliceData):
             sample["acs_mask"] = self.__broadcast_mask(kspace_shape, self.__get_acs_from_fastmri_mask(sampling_mask))
 
         # Explicitly zero-out the outer parts of kspace which are padded
-        sample["kspace"] = self.explicit_zero_padding(sample["kspace"], sample["padding_left"], sample["padding_right"])
+        sample["kspace"] = self.explicit_zero_padding(
+            sample["kspace"], sample["padding_left"], sample["padding_right"]
+        )
 
         if self.transform:
             sample = self.transform(sample)
@@ -1002,9 +1004,9 @@ class SheppLoganDataset(Dataset):
         (self.nx, self.ny, self.nz) = (shape, shape, shape) if isinstance(shape, int) else tuple(shape)
         self.num_coils = num_coils
 
-        assert intensity in self.IMAGE_INTENSITIES, (
-            f"Intensity should be in {self.IMAGE_INTENSITIES}. Received {intensity}."
-        )
+        assert (
+            intensity in self.IMAGE_INTENSITIES
+        ), f"Intensity should be in {self.IMAGE_INTENSITIES}. Received {intensity}."
         self.intensity = intensity
 
         assert len(zlimits) == 2, "`zlimits` must be a tuple with 2 entries: upper and lower bounds!"

--- a/direct/data/datasets_config.py
+++ b/direct/data/datasets_config.py
@@ -139,7 +139,9 @@ class TransformsConfig(BaseConfig):
     masking: Optional[MaskingConfig] = field(default_factory=MaskingConfig)
     cropping: CropTransformConfig = field(default_factory=CropTransformConfig)
     augmentation: AugmentationTransformConfig = field(default_factory=AugmentationTransformConfig)
-    random_augmentations: RandomAugmentationTransformsConfig = field(default_factory=RandomAugmentationTransformsConfig)
+    random_augmentations: RandomAugmentationTransformsConfig = field(
+        default_factory=RandomAugmentationTransformsConfig
+    )
     padding_eps: float = 0.001
     estimate_body_coil_image: bool = False
     sensitivity_map_estimation: SensitivityMapEstimationTransformConfig = field(

--- a/direct/data/lr_scheduler.py
+++ b/direct/data/lr_scheduler.py
@@ -35,8 +35,8 @@ import torch
 
 
 class LRScheduler(torch.optim.lr_scheduler._LRScheduler):  # pylint: disable=protected-access
-    def __init__(self, optimizer, last_epoch=-1, verbose=False):
-        super().__init__(optimizer, last_epoch, verbose)
+    def __init__(self, optimizer, last_epoch=-1):
+        super().__init__(optimizer, last_epoch)
         self.logger = logging.getLogger(type(self).__name__)
 
     def state_dict(self):

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -208,9 +208,7 @@ class RandomFlip(DirectTransform):
                 else (
                     (-1,)
                     if self.flip == "vertical"
-                    else (-2, -1)
-                    if self.flip == "both"
-                    else (random.SystemRandom().choice([-2, -1]),)
+                    else (-2, -1) if self.flip == "both" else (random.SystemRandom().choice([-2, -1]),)
                 )
             )
 

--- a/direct/data/transforms.py
+++ b/direct/data/transforms.py
@@ -822,9 +822,9 @@ def complex_random_crop(
                 raise ValueError(
                     f"Either one sigma has to be set or same as the length of the bounding box. Got {sigma}."
                 )
-        lower_point = (np.random.normal(loc=data_shape / 2, scale=sigma, size=len(data_shape)) - crop_shape / 2).astype(
-            int
-        )
+        lower_point = (
+            np.random.normal(loc=data_shape / 2, scale=sigma, size=len(data_shape)) - crop_shape / 2
+        ).astype(int)
         lower_point = np.clip(lower_point, 0, limits)
     else:
         raise ValueError(f"Sampler is either `uniform` or `gaussian`. Got {sampler}.")

--- a/direct/nn/cirim/cirim_engine.py
+++ b/direct/nn/cirim/cirim_engine.py
@@ -126,7 +126,9 @@ class CIRIMEngine(MRIModelEngine):
             self._scaler.scale(loss).backward()
 
         loss_dicts.append(detach_dict(loss_dict))
-        regularizer_dicts.append(detach_dict(regularizer_dict))  # Need to detach dict as this is only used for logging.
+        regularizer_dicts.append(
+            detach_dict(regularizer_dict)
+        )  # Need to detach dict as this is only used for logging.
 
         # Add the loss dicts.
         loss_dict = reduce_list_of_dicts(loss_dicts, mode="sum")

--- a/direct/nn/conjgradnet/conjgradnet.py
+++ b/direct/nn/conjgradnet/conjgradnet.py
@@ -137,9 +137,9 @@ class ConjGradNet(nn.Module):
         )
         x = self.conj_grad(masked_kspace, sensitivity_map, sampling_mask, z, self.mu)
         for i in range(self.num_steps):
-            z = self.learning_rate[i] * self.nets[i if self.no_parameter_sharing else 0](x.permute(0, 3, 1, 2)).permute(
-                0, 2, 3, 1
-            )
+            z = self.learning_rate[i] * self.nets[i if self.no_parameter_sharing else 0](
+                x.permute(0, 3, 1, 2)
+            ).permute(0, 2, 3, 1)
             x = self.conj_grad(masked_kspace, sensitivity_map, sampling_mask, z, self.mu)
 
         return x

--- a/direct/nn/crossdomain/crossdomain.py
+++ b/direct/nn/crossdomain/crossdomain.py
@@ -197,7 +197,9 @@ class CrossDomainNetwork(nn.Module):
 
         image_buffer = torch.cat([input_image] * self.image_buffer_size, self._complex_dim).to(masked_kspace.device)
 
-        kspace_buffer = torch.cat([masked_kspace] * self.kspace_buffer_size, self._complex_dim).to(masked_kspace.device)
+        kspace_buffer = torch.cat([masked_kspace] * self.kspace_buffer_size, self._complex_dim).to(
+            masked_kspace.device
+        )
 
         kspace_block_idx, image_block_idx = 0, 0
         for block_domain in self.domain_sequence:

--- a/direct/nn/multidomainnet/multidomain.py
+++ b/direct/nn/multidomainnet/multidomain.py
@@ -323,7 +323,9 @@ class MultiDomainUnet2d(nn.Module):
         self.up_transpose_conv = nn.ModuleList()
         for _ in range(num_pool_layers - 1):
             self.up_transpose_conv += [TransposeMultiDomainConvBlock(forward_operator, backward_operator, ch * 2, ch)]
-            self.up_conv += [MultiDomainConvBlock(forward_operator, backward_operator, ch * 2, ch, dropout_probability)]
+            self.up_conv += [
+                MultiDomainConvBlock(forward_operator, backward_operator, ch * 2, ch, dropout_probability)
+            ]
             ch //= 2
 
         self.up_transpose_conv += [TransposeMultiDomainConvBlock(forward_operator, backward_operator, ch * 2, ch)]

--- a/direct/nn/transformers/vit.py
+++ b/direct/nn/transformers/vit.py
@@ -689,7 +689,9 @@ class VisionTransformerBlock(nn.Module):
 class PatchEmbedding(nn.Module):
     """Image to Patch Embedding."""
 
-    def __init__(self, patch_size, in_channels, embedding_dim, dimensionality: VisionTransformerDimensionality) -> None:
+    def __init__(
+        self, patch_size, in_channels, embedding_dim, dimensionality: VisionTransformerDimensionality
+    ) -> None:
         """Inits :class:`PatchEmbedding` module for Vision Transformer.
 
         Parameters

--- a/direct/nn/unet/unet_3d.py
+++ b/direct/nn/unet/unet_3d.py
@@ -388,7 +388,9 @@ class NormUnetModel3d(nn.Module):
         torch.Tensor
             The tensor with padding removed, restored to its original dimensions.
         """
-        return input_data[..., z_pad[0] : z_mult - z_pad[1], h_pad[0] : h_mult - h_pad[1], w_pad[0] : w_mult - w_pad[1]]
+        return input_data[
+            ..., z_pad[0] : z_mult - z_pad[1], h_pad[0] : h_mult - h_pad[1], w_pad[0] : w_mult - w_pad[1]
+        ]
 
     def forward(self, input_data: torch.Tensor) -> torch.Tensor:
         """Performs the forward pass of :class:`NormUnetModel3D`.

--- a/direct/predict.py
+++ b/direct/predict.py
@@ -47,7 +47,9 @@ def predict_from_argparse(args: argparse.Namespace):
     os.environ["OMP_NUM_THREADS"] = "1"
 
     set_all_seeds(args.seed)
-    experiment_directory = args.experiment_directory if args.experiment_directory is not None else args.output_directory
+    experiment_directory = (
+        args.experiment_directory if args.experiment_directory is not None else args.output_directory
+    )
 
     launch(
         setup_inference_save_to_h5,

--- a/direct/utils/asserts.py
+++ b/direct/utils/asserts.py
@@ -68,6 +68,6 @@ def assert_complex(data: torch.Tensor, complex_axis: int = -1, complex_last: Opt
     # TODO: This is because ifft and fft or torch expect the last dimension to represent the complex axis.
     if complex_last:
         complex_axis = -1
-    assert is_complex_data(data, complex_axis), (
-        f"Complex dimension assumed to be 2 (complex valued), but not found in shape {data.shape}."
-    )
+    assert is_complex_data(
+        data, complex_axis
+    ), f"Complex dimension assumed to be 2 (complex valued), but not found in shape {data.shape}."

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     description="DIRECT - Deep Image REConsTruction - is a deep learning framework for MRI reconstruction.",
     entry_points={
         "console_scripts": [
-            "direct=direct.cli:main",
+            "direct=direct.cli.cli:main",
         ],
     },
     setup_requires=["numpy>=1.21.2", "cython>=3.0"],

--- a/tests/tests_data/mri_transforms_test.py
+++ b/tests/tests_data/mri_transforms_test.py
@@ -558,7 +558,9 @@ def test_EstimateSensitivityMap(shape, type_of_map, gaussian_sigma, espirit_iter
         [SensitivityMapType.ESPIRIT, None, 5, True, True],
     ],
 )
-def test_EstimateSensitivityMap3D(shape, type_of_map, gaussian_sigma, espirit_iters, expect_error, sense_map_in_sample):
+def test_EstimateSensitivityMap3D(
+    shape, type_of_map, gaussian_sigma, espirit_iters, expect_error, sense_map_in_sample
+):
     sample = create_sample(
         shape=shape + (2,),
         acs_mask=torch.rand((1,) + shape[1:] + (1,)).round(),

--- a/tests/tests_nn/conjgradnet_test.py
+++ b/tests/tests_nn/conjgradnet_test.py
@@ -42,7 +42,9 @@ def create_input(shape):
         ],
     ],
 )
-@pytest.mark.parametrize("cg_param_update_type", [CGUpdateType.FR, CGUpdateType.PRP, CGUpdateType.DY, CGUpdateType.BAN])
+@pytest.mark.parametrize(
+    "cg_param_update_type", [CGUpdateType.FR, CGUpdateType.PRP, CGUpdateType.DY, CGUpdateType.BAN]
+)
 @pytest.mark.parametrize("image_init", [InitType.SENSE, InitType.ZERO_FILLED, InitType.ZEROS, "invalid"])
 @pytest.mark.parametrize("no_parameter_sharing", [True, False])
 @pytest.mark.parametrize("cg_iters", [5, 20])

--- a/tests/tests_nn/mri_models_test.py
+++ b/tests/tests_nn/mri_models_test.py
@@ -88,7 +88,9 @@ def create_eninge():
             )
 
         def _do_iteration(self, data, loss_fns=None, regularizer_fns=None):
-            output_image = self.model(data["masked_kspace"].sum(self._coil_dim).permute(0, 3, 1, 2)).permute(0, 2, 3, 1)
+            output_image = self.model(data["masked_kspace"].sum(self._coil_dim).permute(0, 3, 1, 2)).permute(
+                0, 2, 3, 1
+            )
             output_image = output_image.sum(self._complex_dim)
 
             return DoIterationOutput(

--- a/tests/tests_ssl/ssl_test.py
+++ b/tests/tests_ssl/ssl_test.py
@@ -27,9 +27,9 @@ def create_sample(shape, **kwargs):
     sample["slice_no"] = [_ for _ in np.random.randint(0, 1000, size=shape[0])]
 
     sample["sampling_mask"] = torch.rand(shape[0], 1, *shape[2:-1], 1).round().bool()
-    sample["sampling_mask"][:, :, shape[2] // 2 - 16 : shape[2] // 2 + 16, shape[3] // 2 - 16 : shape[3] // 2 + 16] = (
-        True
-    )
+    sample["sampling_mask"][
+        :, :, shape[2] // 2 - 16 : shape[2] // 2 + 16, shape[3] // 2 - 16 : shape[3] // 2 + 16
+    ] = True
 
     sample["acs_mask"] = torch.zeros(shape[0], 1, *shape[2:-1], 1).bool()
     sample["acs_mask"][:, :, shape[2] // 2 - 16 : shape[2] // 2 + 16, shape[3] // 2 - 16 : shape[3] // 2 + 16] = True


### PR DESCRIPTION
* This patch corrects the misplaced main entry point (introduced in #285) by relocating it from `direct.cli` to the intended `direct.cli.cli` module. This change ensures that installing the package exposes the CLI correctly.
* The entire codebase has been reformatted using Black v25.1.0. 
* Deprecated uses of the verbose parameter in torch.optim have been removed.