### PR TITLE
Update coverage workflow to align with current pytest pipeline

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,26 +1,35 @@
-name: CodeCov
+name: Coverage
+
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
-  build:
+  coverage:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install coverage
-          pip install -e ".[dev]"
-      - name: Run Coverage
-        run: |
-          coverage run -m pytest --ignore=projects
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v1
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --frozen --python 3.12
+
+      - name: Run tests with coverage
+        run: uv run --frozen coverage run -m pytest --ignore=projects
+
+      - name: Build coverage report
+        run: uv run --frozen coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
### Motivation
- The existing `.github/workflows/coverage.yml` was using an older CI pattern (`actions/setup-python@v2`, manual `pip install`, Python 3.10 matrix) that diverges from the current `tests.yml` setup.  
- Coverage should be an overlay on the pytest run rather than duplicating full environment provisioning logic.  
- Keep CI consistent and simpler by reusing the same runtime/dependency flow used by tests to avoid drift and duplicate maintenance.

### Description
- Rewrote `.github/workflows/coverage.yml` to use `actions/checkout@v4` and `astral-sh/setup-uv@v6` with `uv python install 3.12` and `uv sync --frozen --python 3.12` instead of the old `setup-python` + manual `pip install` flow.  
- Removed the legacy Python matrix and modernized the job to a single `coverage` job that runs `uv run --frozen coverage run -m pytest --ignore=projects` so coverage runs on top of the same test environment.  
- Generate `coverage.xml` with `uv run --frozen coverage xml` and upload it with `codecov/codecov-action@v4` using `files: ./coverage.xml` and `fail_ci_if_error: true`.  
- Updated workflow triggers and metadata (workflow name to `Coverage`, restrict push to `main`) and removed deprecated action usages.

### Testing
- Located relevant CI files with `rg` to confirm targets and that the workflow existed, and the command completed successfully.  
- Verified the diff for `.github/workflows/coverage.yml` using `git status --short && git diff -- .github/workflows/coverage.yml`, which showed the intended changes.  
- Printed the resulting workflow with `nl -ba .github/workflows/coverage.yml | sed -n '1,220p'` to validate the final contents, and the output matched the expected updated steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e317559008322970cd000fede5311)