### PR TITLE
CI: replace CodeCov workflow with Coverage job using `uv` and Python 3.12

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,26 +1,35 @@
-name: CodeCov
+name: Coverage
+
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
-  build:
+  coverage:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install coverage
-          pip install -e ".[dev]"
-      - name: Run Coverage
-        run: |
-          coverage run -m pytest --ignore=projects
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v1
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --frozen --python 3.12
+
+      - name: Run tests with coverage
+        run: uv run --frozen --with coverage python -m coverage run -m pytest --ignore=projects
+
+      - name: Build coverage report
+        run: uv run --frozen --with coverage python -m coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
### Motivation
- Rename and modernize the repository coverage workflow to standardize on `uv`-managed environments and update actions. 
- Produce a coverage XML report and use the latest Codecov action for more reliable uploads and CI failure behavior.

### Description
- Renamed workflow to `Coverage` and scoped triggers to `push` on `main` and `pull_request` events.
- Replaced the previous matrix/job with a single `coverage` job that uses `actions/checkout@v4` and `astral-sh/setup-uv@v6` to enable `uv` tooling. 
- Install Python `3.12` via `uv`, sync pinned dependencies with `uv sync --frozen --python 3.12`, run tests under coverage with `uv run --frozen --with coverage python -m coverage run -m pytest --ignore=projects`, and generate `coverage.xml` with `coverage xml`.
- Upload coverage using `codecov/codecov-action@v4` with `files: ./coverage.xml` and `fail_ci_if_error: true` to surface upload failures in CI.

### Testing
- No automated CI workflow runs were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e317559008322970cd000fede5311)