### PR TITLE
ci: skip musllinux and drop in-build wheel tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           # abi3 (cp312-*) on Linux/macOS; per-version on Windows (see matrix).
           CIBW_BUILD: ${{ matrix.cibw_build }}
           # Skip musllinux: PyTorch (a hard runtime dependency) publishes no
-          # musllinux wheels, so a musllinux `direct` wheel is not installable.
+          # musllinux wheels, so a musllinux `direct-recon` wheel is not installable.
           CIBW_SKIP: "*-musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD_VERBOSITY: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
             py="$repo/.venv/bin/python"
           fi
           uv pip install --python "$py" pytest numpy
-          uv pip install --python "$py" --no-deps --no-index --find-links dist direct-recon
+          uv pip install --python "$py" --no-deps --no-index --find-links dist direct
           # Run from a scratch dir (not the repo root) with importlib import mode
           # so the uncompiled source tree never shadows the installed wheel.
           cd "$RUNNER_TEMP"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
             py="$repo/.venv/bin/python"
           fi
           uv pip install --python "$py" pytest numpy
-          uv pip install --python "$py" --no-deps --no-index --find-links dist direct
+          uv pip install --python "$py" --no-deps --no-index --find-links dist direct-recon
           # Run from a scratch dir (not the repo root) with importlib import mode
           # so the uncompiled source tree never shadows the installed wheel.
           cd "$RUNNER_TEMP"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,10 @@ jobs:
           - platform: macos_arm64
             builder: macos-14
             cibw_archs: arm64
-          # x86_64 is cross-compiled on the arm64 macOS runner; its tests cannot
-          # run here, so they are skipped and covered by smoke-wheels (Rosetta).
+          # x86_64 is cross-compiled on the arm64 macOS runner.
           - platform: macos_x86_64
             builder: macos-14
             cibw_archs: x86_64
-            test_skip: "*"
           - platform: windows_x86_64
             builder: windows-2022
             cibw_archs: AMD64
@@ -91,6 +89,9 @@ jobs:
         env:
           # A single abi3 wheel per platform, built with CPython 3.12.
           CIBW_BUILD: "cp312-*"
+          # Skip musllinux: PyTorch (a hard runtime dependency) publishes no
+          # musllinux wheels, so a musllinux `direct` wheel is not installable.
+          CIBW_SKIP: "*-musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD_VERBOSITY: "1"
           # C++20 (std::numbers, std::span) needs a modern toolchain; the
@@ -101,15 +102,11 @@ jobs:
           # Meson would otherwise auto-select it over MSVC. `--vsenv` activates
           # the Visual Studio environment.
           CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--vsenv"
-          # Run the native extension smoke tests against the freshly built
-          # wheel. cibuildwheel runs this from a temporary directory, and
-          # `--import-mode=importlib` keeps pytest from putting the source tree
-          # (which has no compiled .so) on sys.path, so `import direct` resolves
-          # to the installed wheel.
-          CIBW_TEST_REQUIRES: "pytest numpy"
-          CIBW_TEST_COMMAND: >-
-            python -m pytest --import-mode=importlib {project}/tests/tests_common/_gaussian_native_test.py {project}/tests/tests_common/_poisson_native_test.py {project}/tests/tests_ssl/_gaussian_fill_native_test.py
-          CIBW_TEST_SKIP: ${{ matrix.test_skip }}
+          # No in-build test here: cibuildwheel would `pip install` the wheel
+          # with its full runtime stack (torch + the CUDA wheels), which is slow
+          # and unavailable on some targets. The dedicated `smoke-wheels` job
+          # tests the native extensions against the built wheel with --no-deps
+          # on both 3.12 and 3.13 instead.
       - name: Upload wheel
         if: steps.gate.outputs.run == 'true'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,22 +49,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux/macOS ship a single abi3 wheel (cp312-*) usable on 3.12+.
           - platform: linux_x86_64
             builder: ubuntu-24.04
             cibw_archs: x86_64
+            cibw_build: "cp312-*"
           - platform: linux_aarch64
             builder: ubuntu-24.04-arm
             cibw_archs: aarch64
+            cibw_build: "cp312-*"
           - platform: macos_arm64
             builder: macos-14
             cibw_archs: arm64
+            cibw_build: "cp312-*"
           # x86_64 is cross-compiled on the arm64 macOS runner.
           - platform: macos_x86_64
             builder: macos-14
             cibw_archs: x86_64
+            cibw_build: "cp312-*"
+          # Windows cannot use abi3: the nanobind WrapDB subproject links the
+          # version-specific python3XY import library, so an "abi3" wheel built on
+          # 3.12 actually imports python312.dll and fails to load on 3.13+. Build
+          # per-version wheels instead (limited API disabled below).
           - platform: windows_x86_64
             builder: windows-2022
             cibw_archs: AMD64
+            cibw_build: "cp312-* cp313-*"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -87,8 +97,8 @@ jobs:
           package-dir: .
           output-dir: artifacts/wheels
         env:
-          # A single abi3 wheel per platform, built with CPython 3.12.
-          CIBW_BUILD: "cp312-*"
+          # abi3 (cp312-*) on Linux/macOS; per-version on Windows (see matrix).
+          CIBW_BUILD: ${{ matrix.cibw_build }}
           # Skip musllinux: PyTorch (a hard runtime dependency) publishes no
           # musllinux wheels, so a musllinux `direct` wheel is not installable.
           CIBW_SKIP: "*-musllinux*"
@@ -100,8 +110,10 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           # Force MSVC on Windows: the runner ships MinGW GCC on PATH, and
           # Meson would otherwise auto-select it over MSVC. `--vsenv` activates
-          # the Visual Studio environment.
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--vsenv"
+          # the Visual Studio environment. `-Dpython.allow_limited_api=false`
+          # disables the limited API (overriding pyproject's limited-api=true) so
+          # each interpreter gets a wheel linked against its own pythonXY.dll.
+          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--vsenv setup-args=-Dpython.allow_limited_api=false"
           # No in-build test here: cibuildwheel would `pip install` the wheel
           # with its full runtime stack (torch + the CUDA wheels), which is slow
           # and unavailable on some targets. The dedicated `smoke-wheels` job
@@ -146,7 +158,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Install the cp312-abi3 wheel on 3.12 and 3.13 to prove the stable ABI.
+        # Install on 3.12 and 3.13: proves the abi3 wheel on Linux/macOS and the
+        # per-version wheels on Windows both load on each interpreter.
         python: ["3.12", "3.13"]
         target:
           - platform: linux_x86_64

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 DIRECT: Deep Image REConstruction Toolkit
 =========================================
 
-|JOSS| |Tests| |Ruff| |Codacy| |Codecov|
+|PyPI| |JOSS| |Tests| |Ruff| |Codacy| |Codecov|
 
 `Installation <https://docs.aiforoncology.nl/direct/installation.html>`_ •
 `Quick Start <https://docs.aiforoncology.nl/direct/getting_started.html>`_ •
@@ -29,7 +29,14 @@ For a full list of the baselines currently implemented in DIRECT see `here <#bas
 Quick install
 -------------
 
-The recommended way to install ``DIRECT`` is with `uv <https://docs.astral.sh/uv/>`_:
+``DIRECT`` is published to PyPI as ``direct-recon`` (the import package is still
+``direct``):
+
+.. code-block:: bash
+
+    pip install direct-recon
+
+For development, the recommended way is with `uv <https://docs.astral.sh/uv/>`_:
 
 .. code-block:: bash
 
@@ -76,6 +83,9 @@ If you use DIRECT in your own research, or want to refer to baseline results pub
         journal = {Journal of Open Source Software}
     }
 
+.. |PyPI| image:: https://img.shields.io/pypi/v/direct-recon.svg
+   :target: https://pypi.org/project/direct-recon/
+   :alt: PyPI
 .. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.04278/status.svg
    :target: https://doi.org/10.21105/joss.04278
    :alt: JOSS

--- a/README.rst
+++ b/README.rst
@@ -29,12 +29,11 @@ For a full list of the baselines currently implemented in DIRECT see `here <#bas
 Quick install
 -------------
 
-``DIRECT`` is published to PyPI as ``direct-recon`` (the import package is still
-``direct``):
+``DIRECT`` is published to PyPI as ``direct``:
 
 .. code-block:: bash
 
-    pip install direct-recon
+    pip install direct
 
 For development, the recommended way is with `uv <https://docs.astral.sh/uv/>`_:
 
@@ -83,8 +82,8 @@ If you use DIRECT in your own research, or want to refer to baseline results pub
         journal = {Journal of Open Source Software}
     }
 
-.. |PyPI| image:: https://img.shields.io/pypi/v/direct-recon.svg
-   :target: https://pypi.org/project/direct-recon/
+.. |PyPI| image:: https://img.shields.io/pypi/v/direct.svg
+   :target: https://pypi.org/project/direct/
    :alt: PyPI
 .. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.04278/status.svg
    :target: https://doi.org/10.21105/joss.04278

--- a/README.rst
+++ b/README.rst
@@ -1,40 +1,18 @@
-.. raw:: html
+.. image:: https://github.com/NKI-AI/direct/assets/71031687/14ce8234-7ef1-4e32-84c6-966dc393e7ca
+   :alt: DIRECT
+   :width: 400px
+   :align: center
 
-   <div align="center">
-     <img src="https://github.com/NKI-AI/direct/assets/71031687/14ce8234-7ef1-4e32-84c6-966dc393e7ca"  width="400"/>
-     <br>
-     <figcaption margin-top:10px; font-size:24px !important; font-weight:bold !important;">DIRECT: Deep Image REConstruction Toolkit</figcaption>
+=========================================
+DIRECT: Deep Image REConstruction Toolkit
+=========================================
 
-   </div>
+|JOSS| |Tests| |Ruff| |Codacy| |Codecov|
 
-.. raw:: html
-
-   <div align="center">
-
-   <br />
-
-   <a href="https://doi.org/10.21105/joss.04278">
-   <img src="https://joss.theoj.org/papers/10.21105/joss.04278/status.svg" alt="JOSS"></a>
-   <a href="https://github.com/NKI-AI/direct/actions/workflows/tests.yml">
-   <img src="https://github.com/NKI-AI/direct/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
-   <a href="https://github.com/NKI-AI/direct/actions/workflows/ruff.yml">
-   <img src="https://github.com/NKI-AI/direct/actions/workflows/ruff.yml/badge.svg" alt="Ruff"></a>
-   <a href="https://app.codacy.com/gh/NKI-AI/direct?utm_source=github.com&utm_medium=referral&utm_content=NKI-AI/direct&utm_campaign=Badge_Grade_Settings">
-   <img src="https://api.codacy.com/project/badge/Grade/1c55d497dead4df69d6f256da51c98b7" alt="Codacy"></a>
-   <a href="https://codecov.io/gh/NKI-AI/direct">
-   <img src="https://codecov.io/gh/NKI-AI/direct/branch/main/graph/badge.svg?token=STYAUFCKJY" alt="Codecov"></a>
-
-   </div>
-
-   <p align="center">
-       <a href="https://docs.aiforoncology.nl/direct/installation.html">Installation</a> •
-       <a href="https://docs.aiforoncology.nl/direct/getting_started.html">Quick Start</a> •
-       <a href="https://docs.aiforoncology.nl/direct/index.html">Documentation</a> •
-       <a href="https://docs.aiforoncology.nl/direct/model_zoo.html">Model Zoo</a> <br>
-   </p>
-
-   <br />
-
+`Installation <https://docs.aiforoncology.nl/direct/installation.html>`_ •
+`Quick Start <https://docs.aiforoncology.nl/direct/getting_started.html>`_ •
+`Documentation <https://docs.aiforoncology.nl/direct/index.html>`_ •
+`Model Zoo <https://docs.aiforoncology.nl/direct/model_zoo.html>`_
 
 ``DIRECT`` is a Python, end-to-end pipeline for solving Inverse Problems emerging in Imaging Processing.
 It is built with PyTorch and stores state-of-the-art Deep Learning imaging inverse problem solvers such as denoising, dealiasing and reconstruction.
@@ -42,15 +20,11 @@ By defining a base forward linear or non-linear operator, ``DIRECT`` can be used
 ``DIRECT`` stores inverse problem solvers such as the vSHARP, Learned Primal Dual algorithm, Recurrent Inference Machine and Recurrent Variational Network, which were part of the winning solutions in Facebook & NYUs FastMRI challenge in 2019, the Calgary-Campinas MRI reconstruction challenge at MIDL 2020 and the CMRxRecon challenge 2023.
 For a full list of the baselines currently implemented in DIRECT see `here <#baselines-and-trained-models>`_.
 
-.. raw:: html
+.. figure:: https://raw.githubusercontent.com/NKI-AI/direct/main/.github/direct.png
+   :alt: DIRECT reconstruction examples
+   :align: center
 
-   <div align="center">
-     <img src=".github/direct.png"/>
-     <figcaption>Zero-filled reconstruction, Compressed-Sensing (CS) reconstruction using the BART toolbox, Reconstruction using a RIM model trained with DIRECT</figcaption>
-   </div>
-
-
-
+   Zero-filled reconstruction, Compressed-Sensing (CS) reconstruction using the BART toolbox, Reconstruction using a RIM model trained with DIRECT
 
 Quick install
 -------------
@@ -101,3 +75,19 @@ If you use DIRECT in your own research, or want to refer to baseline results pub
         title = {DIRECT: Deep Image REConstruction Toolkit},
         journal = {Journal of Open Source Software}
     }
+
+.. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.04278/status.svg
+   :target: https://doi.org/10.21105/joss.04278
+   :alt: JOSS
+.. |Tests| image:: https://github.com/NKI-AI/direct/actions/workflows/tests.yml/badge.svg
+   :target: https://github.com/NKI-AI/direct/actions/workflows/tests.yml
+   :alt: Tests
+.. |Ruff| image:: https://github.com/NKI-AI/direct/actions/workflows/ruff.yml/badge.svg
+   :target: https://github.com/NKI-AI/direct/actions/workflows/ruff.yml
+   :alt: Ruff
+.. |Codacy| image:: https://api.codacy.com/project/badge/Grade/1c55d497dead4df69d6f256da51c98b7
+   :target: https://app.codacy.com/gh/NKI-AI/direct
+   :alt: Codacy
+.. |Codecov| image:: https://codecov.io/gh/NKI-AI/direct/branch/main/graph/badge.svg?token=STYAUFCKJY
+   :target: https://codecov.io/gh/NKI-AI/direct
+   :alt: Codecov

--- a/direct/__init__.py
+++ b/direct/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 __author__ = """direct contributors"""
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/installation.rst
+++ b/installation.rst
@@ -110,7 +110,7 @@ Install using ``conda`` (alternative)
 
    .. code-block::
 
-      pip3 install direct
+      pip3 install direct-recon
 
    To build from a checkout instead, clone the repository, navigate to
    ``direct/`` and run

--- a/installation.rst
+++ b/installation.rst
@@ -60,6 +60,34 @@ directly from ``pyproject.toml`` and the committed ``uv.lock``.
       uv run direct --help
       uv run pytest
 
+Install from PyPI (``pip``)
+---------------------------
+
+``DIRECT`` is published to PyPI as ``direct-recon`` (the import package is still
+``direct``). On the supported platforms this fetches a prebuilt ``abi3`` wheel,
+so nothing is compiled:
+
+.. code-block::
+
+   pip install direct-recon
+
+.. code-block:: python
+
+   import direct
+
+If no wheel is available for your platform, ``pip`` builds the C++ extensions
+from the source distribution via ``meson-python`` + ``nanobind`` in an isolated
+build environment; only a working C++20 compiler is required. The conda section
+below shows a step-by-step build, including installing PyTorch with CUDA first.
+
+For an editable/development install, install the build tooling first and disable
+build isolation so the on-import rebuild keeps working:
+
+.. code-block::
+
+   pip install meson-python meson ninja
+   pip install --no-build-isolation -e .
+
 Install using Docker
 --------------------
 

--- a/installation.rst
+++ b/installation.rst
@@ -63,13 +63,12 @@ directly from ``pyproject.toml`` and the committed ``uv.lock``.
 Install from PyPI (``pip``)
 ---------------------------
 
-``DIRECT`` is published to PyPI as ``direct-recon`` (the import package is still
-``direct``). On the supported platforms this fetches a prebuilt ``abi3`` wheel,
-so nothing is compiled:
+``DIRECT`` is published to PyPI as ``direct``. On the supported platforms this
+fetches a prebuilt ``abi3`` wheel, so nothing is compiled:
 
 .. code-block::
 
-   pip install direct-recon
+   pip install direct
 
 .. code-block:: python
 
@@ -138,7 +137,7 @@ Install using ``conda`` (alternative)
 
    .. code-block::
 
-      pip3 install direct-recon
+      pip3 install direct
 
    To build from a checkout instead, clone the repository, navigate to
    ``direct/`` and run

--- a/installation.rst
+++ b/installation.rst
@@ -64,7 +64,8 @@ Install from PyPI (``pip``)
 ---------------------------
 
 ``DIRECT`` is published to PyPI as ``direct``. On the supported platforms this
-fetches a prebuilt ``abi3`` wheel, so nothing is compiled:
+fetches a prebuilt wheel (``abi3`` on Linux/macOS, Python-version-specific on
+Windows), so nothing is compiled:
 
 .. code-block::
 
@@ -133,7 +134,8 @@ Install using ``conda`` (alternative)
 
 #.
    Install ``DIRECT`` from PyPI. On the supported platforms this fetches a
-   prebuilt ``abi3`` wheel, so nothing is compiled:
+   prebuilt wheel (``abi3`` on Linux/macOS, Python-version-specific on
+   Windows), so nothing is compiled:
 
    .. code-block::
 

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 project('direct', 'cpp',
-  version : '2.1.0',
+  version : '2.1.1',
   license : 'Apache-2.0',
   meson_version : '>=1.3',
   default_options : [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,8 @@ requires = ["meson-python>=0.18", "meson>=1.5"]
 build-backend = "mesonpy"
 
 [project]
-# Distribution name on PyPI. The import package is still `direct` (see
-# meson.build / install_subdir), so `pip install direct-recon` then `import direct`.
-name = "direct-recon"
+# Distribution name on PyPI and import package name.
+name = "direct"
 description = "DIRECT - Deep Image REConsTruction - is a deep learning framework for MRI reconstruction."
 readme = "README.rst"
 license = { text = "Apache-2.0" }
@@ -74,12 +73,12 @@ docs = [
 
 [tool.uv]
 default-groups = ["dev", "build"]
-# Build `direct-recon` against the already-synced `build` group instead of an
+# Build `direct` against the already-synced `build` group instead of an
 # isolated build environment. Without this, meson-python's editable install
 # records the absolute path of the isolated build env's `ninja`, which uv later
 # deletes, breaking `import direct` on the next run. Matches the distribution
 # name in `[project] name`, not the import package.
-no-build-isolation-package = ["direct-recon"]
+no-build-isolation-package = ["direct"]
 
 [tool.pytest.ini_options]
 # Keep collection inside the project's own suite; never descend into the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # Static so uv can read metadata without invoking the build backend (required
 # because `direct` is built without isolation; see `[tool.uv]` below). Kept in
 # sync with meson.build and direct/__init__.py by tests/version_test.py.
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
     "numpy>=2.4,<3",
     "h5py>=3.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,10 @@ direct = "direct.cli.cli:main"
 Homepage = "https://github.com/NKI-AI/direct"
 
 [tool.meson-python]
-# The C++ extensions target the CPython 3.12 stable ABI (abi3), so the wheels
-# are tagged `abi3` and a single wheel per platform serves every supported
-# interpreter.
+# The C++ extensions target the CPython 3.12 stable ABI (abi3), so non-Windows
+# wheels are tagged `abi3` and a single wheel per platform serves every
+# supported interpreter. Windows builds override this in the release workflow
+# and emit per-version wheels.
 limited-api = true
 
 [tool.meson-python.args]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ requires = ["meson-python>=0.18", "meson>=1.5"]
 build-backend = "mesonpy"
 
 [project]
-name = "direct"
+# Distribution name on PyPI. The import package is still `direct` (see
+# meson.build / install_subdir), so `pip install direct-recon` then `import direct`.
+name = "direct-recon"
 description = "DIRECT - Deep Image REConsTruction - is a deep learning framework for MRI reconstruction."
 readme = "README.rst"
 license = { text = "Apache-2.0" }
@@ -72,11 +74,12 @@ docs = [
 
 [tool.uv]
 default-groups = ["dev", "build"]
-# Build `direct` against the already-synced `build` group instead of an isolated
-# build environment. Without this, meson-python's editable install records the
-# absolute path of the isolated build env's `ninja`, which uv later deletes,
-# breaking `import direct` on the next run.
-no-build-isolation-package = ["direct"]
+# Build `direct-recon` against the already-synced `build` group instead of an
+# isolated build environment. Without this, meson-python's editable install
+# records the absolute path of the isolated build env's `ninja`, which uv later
+# deletes, breaking `import direct` on the next run. Matches the distribution
+# name in `[project] name`, not the import package.
+no-build-isolation-package = ["direct-recon"]
 
 [tool.pytest.ini_options]
 # Keep collection inside the project's own suite; never descend into the

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -50,8 +50,8 @@ def _pyproject_version() -> str:
 
 
 def test_dunder_version_matches_installed_metadata() -> None:
-    # Distribution name (PyPI) is `direct-recon`; the import package is `direct`.
-    assert direct.__version__ == importlib.metadata.version("direct-recon")
+    # Distribution name (PyPI) matches the import package.
+    assert direct.__version__ == importlib.metadata.version("direct")
 
 
 def test_pyproject_version_matches_dunder_version() -> None:

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -50,7 +50,8 @@ def _pyproject_version() -> str:
 
 
 def test_dunder_version_matches_installed_metadata() -> None:
-    assert direct.__version__ == importlib.metadata.version("direct")
+    # Distribution name (PyPI) is `direct-recon`; the import package is `direct`.
+    assert direct.__version__ == importlib.metadata.version("direct-recon")
 
 
 def test_pyproject_version_matches_dunder_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'ios'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -259,7 +259,7 @@ nvtx = [
 ]
 
 [[package]]
-name = "direct"
+name = "direct-recon"
 version = "2.1.0"
 source = { editable = "." }
 dependencies = [
@@ -853,7 +853,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'ios'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -892,7 +892,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'ios'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -904,7 +904,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'ios'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -934,9 +934,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'ios'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'ios'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'ios'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -948,7 +948,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'ios'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ nvtx = [
 ]
 
 [[package]]
-name = "direct-recon"
+name = "direct"
 version = "2.1.1"
 source = { editable = "." }
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ nvtx = [
 
 [[package]]
 name = "direct-recon"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
PyTorch ships no musllinux wheels, so a musllinux `direct` wheel is not installable; skip it. Also drop cibuildwheel's in-build test, which would `pip install` the wheel with its full runtime stack (torch + CUDA wheels) just to run numpy-only native smoke tests. The dedicated smoke-wheels job already exercises the abi3 wheels with --no-deps on 3.12 and 3.13.