### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/direct/__init__.py
+++ b/direct/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 __author__ = """direct contributors"""
-__version__ = "2.1.1"
+__version__ = "2.2.0"

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,4 +8,5 @@ History
 **19 Oct 2022**: Release of version `1.0.4 <https://github.com/NKI-AI/direct/releases/tag/v1.0.4>`_.
 **02 Apr 2024**: Release of version `2.0.0 <https://github.com/NKI-AI/direct/releases/tag/v2.0.0>`_.
 **03 Jul 2024**: Release of version `2.1.0 <https://github.com/NKI-AI/direct/releases/tag/v2.1.0>`_.
+**21 Aug 2026**: Release of version `2.2.0 <https://github.com/NKI-AI/direct/releases/tag/v2.2.0>`_.
 

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 project('direct', 'cpp',
-  version : '2.1.1',
+  version : '2.2.0',
   license : 'Apache-2.0',
   meson_version : '>=1.3',
   default_options : [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # Static so uv can read metadata without invoking the build backend (required
 # because `direct` is built without isolation; see `[tool.uv]` below). Kept in
 # sync with meson.build and direct/__init__.py by tests/version_test.py.
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
     "numpy>=2.4,<3",
     "h5py>=3.16",

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ nvtx = [
 
 [[package]]
 name = "direct-recon"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
Release bump after adaptive sampling / registration merge.